### PR TITLE
handle older versions of win32-process

### DIFF
--- a/lib/buff/shell_out.rb
+++ b/lib/buff/shell_out.rb
@@ -31,7 +31,9 @@ module Buff
         begin
           pid         = Process.spawn(command, out: out.to_i, err: err.to_i)
           pid, status = Process.waitpid2(pid)
-          exitstatus  = status.exitstatus
+          # Check if we're getting back a process status because win32-process 6.x was a fucking MURDERER.
+          # https://github.com/djberg96/win32-process/blob/master/lib/win32/process.rb#L494-L519
+          exitstatus  = status.is_a?(Process::Status) ? status.exitstatus : status
         rescue Errno::ENOENT => ex
           exitstatus = 127
           out.write("")

--- a/spec/buff/shell_out_spec.rb
+++ b/spec/buff/shell_out_spec.rb
@@ -23,6 +23,14 @@ describe Buff::ShellOut do
         described_class.should_receive(:mri_out).with(command)
         result
       end
+
+      context "when Process.waitpid2 returns an Integer instead of a Process::Status" do
+        before { Process.stub(:waitpid2).and_return([12345, 0]) }
+
+        it "sets the exitstatus to the returned integer" do
+          expect(result.exitstatus).to eql(0)
+        end
+      end
     end
 
     context "when on JRuby" do


### PR DESCRIPTION
https://github.com/djberg96/win32-process/blob/master/lib/win32/process.rb#L494-L519

This was fixed in a more recent version of win32-process but the 0.6.x series is pretty wide spread.
